### PR TITLE
chore(lint): line width, comments, tweaks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
+max_line_length = 90
 
 [{Makefile,go.mod,go.sum,*.go,.gitmodules}]
 indent_style = tab

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,26 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,10 +14,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@19bb51245e9c80abacb2e91cc42b33fa478b8639 # v4.2.1
 
     - name: Build
       run: go build -v ./...

--- a/cmd/current.go
+++ b/cmd/current.go
@@ -46,7 +46,13 @@ var currentCmd = &cobra.Command{
 		duration := time.Since(currentEntry.Start).Seconds()
 		projectName := projectsMap[currentEntry.ProjectID]
 		rows := [][]interface{}{
-			{currentEntry.ID, currentEntry.Start.Format("02.01.2006 15:04"), api.FormatDuration(duration), currentEntry.Description, projectName},
+			{
+				currentEntry.ID,
+				currentEntry.Start.Format("02.01.2006 15:04"),
+				api.FormatDuration(duration),
+				currentEntry.Description,
+				projectName,
+			},
 		}
 
 		utils.RenderTable(headers, rows)

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -30,6 +30,7 @@ var historyCmd = &cobra.Command{
 		projects, err := client.GetProjects(workspaceId)
 		if err != nil {
 			log.Println("Failed to get projects:", err)
+
 			return
 		}
 
@@ -39,6 +40,7 @@ var historyCmd = &cobra.Command{
 		timeEntries, err := client.GetHistory(&startTime, &endTime)
 		if err != nil {
 			log.Println("Failed to get history:", err)
+
 			return
 		}
 
@@ -50,7 +52,13 @@ var historyCmd = &cobra.Command{
 			formattedDuration := api.FormatDuration(float64(entry.Duration))
 			projectName := projectsLookup[entry.ProjectID]
 
-			t.AppendRow([]interface{}{entry.ID, entry.Start.Format("02.01.2006 15:04"), formattedDuration, entry.Description, projectName})
+			t.AppendRow([]interface{}{
+				entry.ID,
+				entry.Start.Format("02.01.2006 15:04"),
+				formattedDuration,
+				entry.Description,
+				projectName,
+			})
 		}
 
 		t.Render()
@@ -62,6 +70,7 @@ func toProjectsLookup(projects []api.Project) map[int]string {
 	for _, project := range projects {
 		lookup[project.ID] = project.Name
 	}
+
 	return lookup
 }
 
@@ -88,12 +97,14 @@ func getDateParams(cmd *cobra.Command) (time.Time, time.Time) {
 	if err != nil {
 		log.Fatal("Error retrieving start flag:", err)
 	}
+
 	startTime := getTimeWithDefault(start, time.Now().AddDate(0, 0, -7))
 
 	end, err := cmd.Flags().GetString("end")
 	if err != nil {
 		log.Fatal("Error retrieving end flag:", err)
 	}
+
 	endTime := getTimeWithDefault(end, time.Now())
 
 	return startTime, endTime
@@ -111,7 +122,7 @@ func getCurrentWeekTimeInterval() (time.Time, time.Time) {
 
 func getCurrentMonthTimeInterval() (time.Time, time.Time) {
 	start := time.Now()
-	start = start.AddDate(0, 0, -int(start.Day()-1))
+	start = start.AddDate(0, 0, -(start.Day() - 1))
 	end := start.AddDate(0, 1, 0)
 
 	return start, end

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,7 +10,7 @@ import (
 
 var cfgFile string
 
-// rootCmd represents the base command when called without any subcommands
+// rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
 	Use:   "toggl-cli",
 	Short: "Toggl CLI is a command line interface for Toggl",
@@ -36,7 +36,12 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.toggl-cli.yaml)")
+	rootCmd.PersistentFlags().StringVar(
+		&cfgFile,
+		"config",
+		"",
+		"config file (default is $HOME/.toggl-cli.yaml)",
+	)
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
@@ -63,6 +68,9 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+		_, fmtErr := fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+		if fmtErr != nil {
+			fmt.Println("Error printing config file used:", fmtErr)
+		}
 	}
 }

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -52,7 +52,13 @@ var stopCmd = &cobra.Command{
 		duration := float64(stoppedEntry.Duration)
 		projectName := projectsMap[currentEntry.ProjectID]
 		rows := [][]interface{}{
-			{stoppedEntry.ID, stoppedEntry.Start.Format("02.01.2006 15:04"), api.FormatDuration(duration), stoppedEntry.Description, projectName},
+			{
+				stoppedEntry.ID,
+				stoppedEntry.Start.Format("02.01.2006 15:04"),
+				api.FormatDuration(duration),
+				stoppedEntry.Description,
+				projectName,
+			},
 		}
 
 		utils.RenderTable(headers, rows)

--- a/internal/utils/table.go
+++ b/internal/utils/table.go
@@ -4,7 +4,8 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 	"os"
 )
-
+// RenderTable renders a table to the standard output.
+// It takes headers and rows as parameters.
 func RenderTable(headers []interface{}, rows [][]interface{}) {
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)


### PR DESCRIPTION
This pull request includes several changes that improve code readability, add a new GitHub Actions workflow for Go projects, and enhance error handling. The most important changes are grouped below by theme.

### Workflow and Configuration Updates:
* Added a new GitHub Actions workflow (`.github/workflows/go.yml`) to build and test the Go project on pushes and pull requests targeting the `main` branch.
* Updated `.editorconfig` to include a `max_line_length` of 90 for better code formatting consistency.

### Code Readability Improvements:
* Reformatted multi-line `AppendRow` and `RenderTable` calls in `cmd/history.go`, `cmd/current.go`, and `cmd/stop.go` for better readability. [[1]](diffhunk://#diff-89f84ce9096e121910561afcdf673bf8d3c6c11f448f0612d127e407c82935adL49-R55) [[2]](diffhunk://#diff-fcbde1a92e7a1c01f031f8d54a51161a95f287cea3985819eadaf814bc79714eL53-R61) [[3]](diffhunk://#diff-9d672277c9ba9fd61b0aa798d540335c62e449af9299a0804340ba847ea9b5bdL55-R61)
* Updated the `rootCmd.PersistentFlags().StringVar` call in `cmd/root.go` to use a multi-line format for improved clarity.

### Error Handling Enhancements:
* Added error handling for `fmt.Fprintln` in `cmd/root.go` to handle potential output errors when printing the config file path.

### Minor Code Adjustments:
* Fixed a minor formatting issue in the `getCurrentMonthTimeInterval` function in `cmd/history.go` by adjusting the subtraction logic for clarity.
* Added comments to the `RenderTable` function in `internal/utils/table.go` to explain its purpose and parameters.