### PR TITLE
feat: renamed APIClient to Client

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,26 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...

--- a/internal/api/toggl-client.go
+++ b/internal/api/toggl-client.go
@@ -5,14 +5,14 @@ import (
 	"time"
 )
 
-type APIClient struct {
+type Client struct {
 	BaseURL    string
 	HTTPClient *http.Client
 	AuthToken  string
 }
 
-func NewAPIClient(authToken string) *APIClient {
-	return &APIClient{
+func NewAPIClient(authToken string) *Client {
+	return &Client{
 		BaseURL: "https://api.track.toggl.com/api/v9",
 		HTTPClient: &http.Client{
 			Timeout: 10 * time.Second,

--- a/internal/api/toggl-service.go
+++ b/internal/api/toggl-service.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-func (c *APIClient) GetWorkspaces() ([]Workspace, error) {
+func (c *Client) GetWorkspaces() ([]Workspace, error) {
 	req, err := c.newRequest(http.MethodGet, "/workspaces", nil)
 	if err != nil {
 		return nil, err
@@ -25,7 +25,7 @@ func (c *APIClient) GetWorkspaces() ([]Workspace, error) {
 	return workspaces, nil
 }
 
-func (c *APIClient) GetCurrentTimerEntry() (*TimeEntryItem, error) {
+func (c *Client) GetCurrentTimerEntry() (*TimeEntryItem, error) {
 	req, err := c.newRequest(http.MethodGet, "/me/time_entries/current", nil)
 	if err != nil {
 		return nil, err
@@ -39,7 +39,7 @@ func (c *APIClient) GetCurrentTimerEntry() (*TimeEntryItem, error) {
 	return &entry, nil
 }
 
-func (c *APIClient) CreateTimeEntry(workspaceId int, entry TimeEntry) (*TimeEntry, error) {
+func (c *Client) CreateTimeEntry(workspaceId int, entry TimeEntry) (*TimeEntry, error) {
 	endpoint := fmt.Sprintf("/workspaces/%d/time_entries", workspaceId)
 	req, err := c.newRequest(http.MethodPost, endpoint, entry)
 	if err != nil {
@@ -54,7 +54,7 @@ func (c *APIClient) CreateTimeEntry(workspaceId int, entry TimeEntry) (*TimeEntr
 	return &createdEntry, nil
 }
 
-func (c *APIClient) StopTimeEntry(workspaceId int, entryId int) (*TimeEntryItem, error) {
+func (c *Client) StopTimeEntry(workspaceId int, entryId int) (*TimeEntryItem, error) {
 	endpoint := fmt.Sprintf("/workspaces/%d/time_entries/%d/stop", workspaceId, entryId)
 	req, err := c.newRequest(http.MethodPatch, endpoint, nil)
 	if err != nil {
@@ -69,7 +69,7 @@ func (c *APIClient) StopTimeEntry(workspaceId int, entryId int) (*TimeEntryItem,
 	return &stoppedEntry, nil
 }
 
-func (c *APIClient) GetProjects(workspaceId int) ([]Project, error) {
+func (c *Client) GetProjects(workspaceId int) ([]Project, error) {
 	endpoint := fmt.Sprintf("/workspaces/%d/projects", workspaceId)
 	req, err := c.newRequest(http.MethodGet, endpoint, nil)
 	if err != nil {
@@ -84,7 +84,7 @@ func (c *APIClient) GetProjects(workspaceId int) ([]Project, error) {
 	return projects, nil
 }
 
-func (c *APIClient) GetProjectIdByName(workspaceId int, projectName string) (int, error) {
+func (c *Client) GetProjectIdByName(workspaceId int, projectName string) (int, error) {
 	projects, err := c.GetProjects(workspaceId)
 	if err != nil {
 		return 0, err
@@ -99,7 +99,7 @@ func (c *APIClient) GetProjectIdByName(workspaceId int, projectName string) (int
 	return 0, fmt.Errorf("project '%s' not found", projectName)
 }
 
-func (c *APIClient) GetHistory(from, to *time.Time) ([]TimeEntryItem, error) {
+func (c *Client) GetHistory(from, to *time.Time) ([]TimeEntryItem, error) {
 	endpoint := "/me/time_entries"
 	queryParams := make([]string, 0)
 	if from != nil {
@@ -127,7 +127,7 @@ func (c *APIClient) GetHistory(from, to *time.Time) ([]TimeEntryItem, error) {
 	return timeEntries, nil
 }
 
-func (c *APIClient) GetProjectsLookupMap(workspaceId int) (map[int]string, error) {
+func (c *Client) GetProjectsLookupMap(workspaceId int) (map[int]string, error) {
 	projects, err := c.GetProjects(workspaceId)
 	if err != nil {
 		return nil, err
@@ -149,7 +149,7 @@ func FormatDuration(seconds float64) string {
 	return fmt.Sprintf("%02d:%02d:%02d", hours, minutes, secs)
 }
 
-func (c *APIClient) newRequest(method, endpoint string, body any) (*http.Request, error) {
+func (c *Client) newRequest(method, endpoint string, body any) (*http.Request, error) {
 	var buf io.Reader
 	if body != nil {
 		jsonData, err := json.Marshal(body)
@@ -169,7 +169,7 @@ func (c *APIClient) newRequest(method, endpoint string, body any) (*http.Request
 	return req, nil
 }
 
-func (c *APIClient) doRequest(req *http.Request, expectedStatus int, result any) error {
+func (c *Client) doRequest(req *http.Request, expectedStatus int, result any) error {
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return err
@@ -187,7 +187,7 @@ func (c *APIClient) doRequest(req *http.Request, expectedStatus int, result any)
 	return nil
 }
 
-func (c *APIClient) setDefaultRequestHeaders(req *http.Request) {
+func (c *Client) setDefaultRequestHeaders(req *http.Request) {
 	token := base64.StdEncoding.EncodeToString([]byte(c.AuthToken + ":api_token"))
 
 	req.Header.Set("Authorization", "Basic "+token)


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building and testing a Go project and refactors the Toggl API client by renaming the `APIClient` struct to `Client`. The changes aim to standardize naming and improve maintainability.

### CI/CD Workflow Addition:

* Added a new GitHub Actions workflow (`.github/workflows/go.yml`) to automate the build and test process for the Go project. It triggers on pushes and pull requests to the `main` branch, sets up the Go environment, builds the project, and runs tests.

### Toggl API Client Refactor:

* Renamed the `APIClient` struct to `Client` across `internal/api/toggl-client.go` and `internal/api/toggl-service.go`. This includes updating all associated methods and function signatures to use the new name, ensuring consistency and clarity. [[1]](diffhunk://#diff-4068535dadd1e3c43abb89394d7c707f75eb01f43705aa2514632e4ce9e75bdaL8-R15) [[2]](diffhunk://#diff-87123d7ab29266afa182f24e93948104d31e94bca9ceb0bf3490288c88865536L14-R14) [[3]](diffhunk://#diff-87123d7ab29266afa182f24e93948104d31e94bca9ceb0bf3490288c88865536L28-R28) [[4]](diffhunk://#diff-87123d7ab29266afa182f24e93948104d31e94bca9ceb0bf3490288c88865536L42-R42) [[5]](diffhunk://#diff-87123d7ab29266afa182f24e93948104d31e94bca9ceb0bf3490288c88865536L57-R57) [[6]](diffhunk://#diff-87123d7ab29266afa182f24e93948104d31e94bca9ceb0bf3490288c88865536L72-R72) [[7]](diffhunk://#diff-87123d7ab29266afa182f24e93948104d31e94bca9ceb0bf3490288c88865536L87-R87) [[8]](diffhunk://#diff-87123d7ab29266afa182f24e93948104d31e94bca9ceb0bf3490288c88865536L102-R102) [[9]](diffhunk://#diff-87123d7ab29266afa182f24e93948104d31e94bca9ceb0bf3490288c88865536L130-R130) [[10]](diffhunk://#diff-87123d7ab29266afa182f24e93948104d31e94bca9ceb0bf3490288c88865536L152-R152) [[11]](diffhunk://#diff-87123d7ab29266afa182f24e93948104d31e94bca9ceb0bf3490288c88865536L172-R172) [[12]](diffhunk://#diff-87123d7ab29266afa182f24e93948104d31e94bca9ceb0bf3490288c88865536L190-R190)

This is part of the linting PR #14, but created as it's own because it's nature.