### PR TITLE
feat: display history entries grouped by description and project

### DIFF
--- a/cmd/current.go
+++ b/cmd/current.go
@@ -56,7 +56,7 @@ var currentCmd = &cobra.Command{
 			},
 		}
 
-		utils.RenderTable(headers, rows)
+		utils.RenderTable("Current timer entry", headers, rows, nil)
 	},
 }
 

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -46,10 +46,7 @@ var stopCmd = &cobra.Command{
 			log.Fatal("Failed to get projects", err)
 		}
 
-		fmt.Println("Stopped time entry")
-
 		headers := []interface{}{"#", "Started At", "Duration", "Description", "Project"}
-
 		duration := float64(stoppedEntry.Duration)
 		projectName := projectsMap[currentEntry.ProjectID]
 		rows := [][]interface{}{
@@ -62,7 +59,7 @@ var stopCmd = &cobra.Command{
 			},
 		}
 
-		utils.RenderTable(headers, rows)
+		utils.RenderTable("Stopped timer entry", headers, rows, nil)
 	},
 }
 

--- a/internal/utils/table.go
+++ b/internal/utils/table.go
@@ -8,13 +8,27 @@ import (
 
 // RenderTable renders a table to the standard output.
 // It takes headers and rows as parameters.
-func RenderTable(headers []interface{}, rows [][]interface{}) {
+func RenderTable(
+	title string,
+	headers []interface{},
+	rows [][]interface{},
+	footer table.Row,
+) {
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)
+
+	if title != "" {
+		t.SetTitle(title)
+	}
+
 	t.AppendHeader(headers)
 
 	for _, row := range rows {
 		t.AppendRow(row)
+	}
+
+	if footer != nil {
+		t.AppendFooter(footer)
 	}
 
 	t.Render()


### PR DESCRIPTION
This pull request introduces several enhancements to the CLI tool's command functionalities and output formatting. Key updates include adding summary tables for time entries, introducing a verbose mode for detailed output, improving table rendering with titles and footers, and refining date handling logic.

### Enhancements to `history` command:

* Added a verbose mode (`--verbose`) to display detailed time entries for each day, and implemented summary tables to show aggregated time entries by description and project. (`cmd/history.go`: [[1]](diffhunk://#diff-fcbde1a92e7a1c01f031f8d54a51161a95f287cea3985819eadaf814bc79714eR37-R41) [[2]](diffhunk://#diff-fcbde1a92e7a1c01f031f8d54a51161a95f287cea3985819eadaf814bc79714eR67-R133) [[3]](diffhunk://#diff-fcbde1a92e7a1c01f031f8d54a51161a95f287cea3985819eadaf814bc79714eR272)
* Adjusted the default end date to include the next day when the `--end` flag is not provided. (`cmd/history.go`: [cmd/history.goL159-R231](diffhunk://#diff-fcbde1a92e7a1c01f031f8d54a51161a95f287cea3985819eadaf814bc79714eL159-R231))

### Improvements to table rendering:

* Updated the `RenderTable` function to support optional titles and footers, enhancing the readability of table outputs. (`internal/utils/table.go`: [internal/utils/table.goL11-R33](diffhunk://#diff-d5cfb1bb07a4df2999238be0e5eb26a9bc9f877ada19ca70435ff0669e2b0965L11-R33))
* Incorporated titles for time entry tables, such as "Entries for: [date]" and "Summary for: [date]". (`cmd/history.go`: [[1]](diffhunk://#diff-fcbde1a92e7a1c01f031f8d54a51161a95f287cea3985819eadaf814bc79714eL74-R146) [[2]](diffhunk://#diff-fcbde1a92e7a1c01f031f8d54a51161a95f287cea3985819eadaf814bc79714eL91-R163)

### Updates to `current` and `stop` commands:

* Added titles like "Current timer entry" and "Stopped timer entry" to the respective table outputs for better clarity. (`cmd/current.go`: [[1]](diffhunk://#diff-89f84ce9096e121910561afcdf673bf8d3c6c11f448f0612d127e407c82935adL59-R59) `cmd/stop.go`: [[2]](diffhunk://#diff-9d672277c9ba9fd61b0aa798d540335c62e449af9299a0804340ba847ea9b5bdL65-R62)

These changes enhance the user experience by making the CLI outputs more informative and visually structured.