### PR TITLE
tidy: reduce config fetching duplication

### DIFF
--- a/cmd/continue.go
+++ b/cmd/continue.go
@@ -2,10 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/ville6000/toggl-cli/internal/utils"
 	"log"
 	"time"
 
-	"github.com/spf13/viper"
 	"github.com/ville6000/toggl-cli/internal/api"
 
 	"github.com/spf13/cobra"
@@ -16,16 +16,7 @@ var continueCmd = &cobra.Command{
 	Short: "Continue latest timer entry",
 	Long:  "",
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("toggl.token")
-		if token == "" {
-			log.Fatal("Missing toggl.token in config file")
-		}
-
-		workspaceId := viper.GetInt("toggl.workspace_id")
-		if workspaceId == 0 {
-			log.Fatal("Missing toggl.workspace_id in config file")
-		}
-
+		token, workspaceId := utils.GetTogglConfig()
 		client := api.NewAPIClient(token)
 		timeEntries, err := client.GetHistory(nil, nil)
 		if err != nil {

--- a/cmd/current.go
+++ b/cmd/current.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"github.com/ville6000/toggl-cli/internal/api"
 	"github.com/ville6000/toggl-cli/internal/utils"
 )
@@ -16,16 +15,7 @@ var currentCmd = &cobra.Command{
 	Short: "Get the current timer entry",
 	Long:  "Get the current timer entry from Toggl.",
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("toggl.token")
-		if token == "" {
-			log.Fatal("Missing toggl.token in config file")
-		}
-
-		workspaceId := viper.GetInt("toggl.workspace_id")
-		if workspaceId == 0 {
-			log.Fatal("Missing toggl.workspace_id in config file")
-		}
-
+		token, workspaceId := utils.GetTogglConfig()
 		client := api.NewAPIClient(token)
 		currentEntry, err := client.GetCurrentTimerEntry()
 		if err != nil {

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"github.com/ville6000/toggl-cli/internal/api"
 	"github.com/ville6000/toggl-cli/internal/utils"
 )
@@ -24,16 +23,7 @@ var historyCmd = &cobra.Command{
 	Short: "Fetch the history of time entries",
 	Long:  "Fetch the history of time entries from Toggl",
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("toggl.token")
-		if token == "" {
-			log.Fatal("Missing toggl.token in config file")
-		}
-
-		workspaceId := viper.GetInt("toggl.workspace_id")
-		if workspaceId == 0 {
-			log.Fatal("Missing toggl.workspace_id in config file")
-		}
-
+		token, workspaceId := utils.GetTogglConfig()
 		displayVerboseOutput, err := cmd.Flags().GetBool("verbose")
 		if err != nil {
 			log.Fatal("Error retrieving verbose flag:", err)

--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/ville6000/toggl-cli/internal/utils"
 	"log"
 
-	"github.com/spf13/viper"
 	"github.com/ville6000/toggl-cli/internal/api"
 
 	"github.com/spf13/cobra"
@@ -15,16 +15,7 @@ var projectsCmd = &cobra.Command{
 	Short: "List projects",
 	Long:  "List all projects associated with the default workspace",
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("toggl.token")
-		if token == "" {
-			log.Fatal("Missing toggl.token in config file")
-		}
-
-		workspaceId := viper.GetInt("toggl.workspace_id")
-		if workspaceId == 0 {
-			log.Fatal("Missing toggl.workspace_id in config file")
-		}
-
+		token, workspaceId := utils.GetTogglConfig()
 		client := api.NewAPIClient(token)
 		projects, err := client.GetProjects(workspaceId)
 		if err != nil {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -2,13 +2,13 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/ville6000/toggl-cli/internal/utils"
 	"log"
 	"time"
 
 	"github.com/ville6000/toggl-cli/internal/api"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var startCmd = &cobra.Command{
@@ -16,16 +16,7 @@ var startCmd = &cobra.Command{
 	Short: "Start a new time entry",
 	Long:  "",
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("toggl.token")
-		if token == "" {
-			log.Fatal("Missing toggl.token in config file")
-		}
-
-		workspaceId := viper.GetInt("toggl.workspace_id")
-		if workspaceId == 0 {
-			log.Fatal("Missing toggl.workspace_id in config file")
-		}
-
+		token, workspaceId := utils.GetTogglConfig()
 		description := args[0]
 		projectName, err := cmd.Flags().GetString("project")
 		if err != nil {

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"github.com/ville6000/toggl-cli/internal/api"
 	"github.com/ville6000/toggl-cli/internal/utils"
 )
@@ -15,16 +14,7 @@ var stopCmd = &cobra.Command{
 	Short: "Stop the current timer entry",
 	Long:  "",
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("toggl.token")
-		if token == "" {
-			log.Fatal("Missing toggl.token in config file")
-		}
-
-		workspaceId := viper.GetInt("toggl.workspace_id")
-		if workspaceId == 0 {
-			log.Fatal("Missing toggl.workspace_id in config file")
-		}
-
+		token, workspaceId := utils.GetTogglConfig()
 		client := api.NewAPIClient(token)
 		currentEntry, err := client.GetCurrentTimerEntry()
 		if err != nil {

--- a/cmd/workspaces.go
+++ b/cmd/workspaces.go
@@ -2,10 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/ville6000/toggl-cli/internal/utils"
 	"log"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"github.com/ville6000/toggl-cli/internal/api"
 )
 
@@ -14,11 +14,7 @@ var workspacesCmd = &cobra.Command{
 	Short: "List workspaces",
 	Long:  "List all workspaces associated with the Toggl account.",
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("toggl.token")
-		if token == "" {
-			log.Fatal("Missing toggl.token in config file")
-		}
-
+		token, _ := utils.GetTogglConfig()
 		client := api.NewAPIClient(token)
 		workspaces, err := client.GetWorkspaces()
 		if err != nil {

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"github.com/spf13/viper"
+	"log"
+)
+
+func GetTogglConfig() (string, int) {
+	token := viper.GetString("toggl.token")
+	if token == "" {
+		log.Fatal("Missing toggl.token in config file")
+	}
+
+	workspaceId := viper.GetInt("toggl.workspace_id")
+	if workspaceId == 0 {
+		log.Fatal("Missing toggl.workspace_id in config file")
+	}
+
+	return token, workspaceId
+}


### PR DESCRIPTION
This pull request refactors the Toggl CLI commands to centralize configuration handling and improve code maintainability by introducing a new utility function, `GetTogglConfig`. The changes replace repeated configuration retrieval code across multiple command files with calls to this new utility function.

### Centralized Configuration Handling:
* Added a new utility function `GetTogglConfig` in `internal/utils/config.go` to centralize the retrieval of `toggl.token` and `toggl.workspace_id` from the configuration file. This function also handles validation and logs errors if the required configuration values are missing.

### Refactoring Command Files:
* Replaced inline configuration retrieval and validation logic with calls to `utils.GetTogglConfig` in the following command files:
  - `cmd/continue.go`
  - `cmd/current.go`
  - `cmd/history.go`
  - `cmd/projects.go`
  - `cmd/start.go`
  - `cmd/stop.go`
  - `cmd/workspaces.go`

### Dependency Cleanup:
* Removed unused imports of `github.com/spf13/viper` from all affected command files since the configuration logic is now encapsulated in the `utils` package. [[1]](diffhunk://#diff-c81692ce703f798f07159bea7fd272c8dd598cc9eb19762b29659cdfd6951cbcR5-L8) [[2]](diffhunk://#diff-89f84ce9096e121910561afcdf673bf8d3c6c11f448f0612d127e407c82935adL9) [[3]](diffhunk://#diff-fcbde1a92e7a1c01f031f8d54a51161a95f287cea3985819eadaf814bc79714eL11) [[4]](diffhunk://#diff-e82952d2819fa0443c40e71a2fe089728d309318d933843449ff63d6ccd3ef2dR5-L7) [[5]](diffhunk://#diff-e3ad76770e5ac8ed654e8c5585782469e67e0d981adb9153604109263f22e93eR5-R19) [[6]](diffhunk://#diff-9d672277c9ba9fd61b0aa798d540335c62e449af9299a0804340ba847ea9b5bdL8) [[7]](diffhunk://#diff-545d8e6066af5675e676207857197c7ab40384cc8acd2b5af49d4211828733f2R5-L8)