### PR TITLE
tidy: centralise time entry creation

### DIFF
--- a/cmd/continue.go
+++ b/cmd/continue.go
@@ -2,11 +2,10 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/ville6000/toggl-cli/internal/utils"
 	"log"
-	"time"
 
 	"github.com/ville6000/toggl-cli/internal/api"
+	"github.com/ville6000/toggl-cli/internal/utils"
 
 	"github.com/spf13/cobra"
 )
@@ -28,24 +27,18 @@ var continueCmd = &cobra.Command{
 			return
 		}
 
-		latestEntry := timeEntries[0]
-		timeEntry := api.TimeEntry{
-			CreatedWith: "toggl-cli",
-			Description: latestEntry.Description,
-			Tags:        latestEntry.Tags,
-			Billable:    latestEntry.Billable,
-			WorkspaceID: workspaceId,
-			Duration:    -1,
-			Start:       time.Now().Format(time.RFC3339),
-			ProjectID:   latestEntry.ProjectID,
-		}
-
+		e := timeEntries[0]
+		timeEntry := client.NewTimeEntry(e.Description,
+			workspaceId,
+			e.ProjectID,
+			e.Billable,
+		)
 		_, err = client.CreateTimeEntry(workspaceId, timeEntry)
 		if err != nil {
 			log.Fatal("Failed to create time entry:", err)
 		}
 
-		fmt.Println("Continuing timer for:", latestEntry.Description)
+		fmt.Println("Continuing timer for:", e.Description)
 	},
 }
 

--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -2,8 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/ville6000/toggl-cli/internal/utils"
 	"log"
+
+	"github.com/ville6000/toggl-cli/internal/utils"
 
 	"github.com/ville6000/toggl-cli/internal/api"
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -2,11 +2,10 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/ville6000/toggl-cli/internal/utils"
 	"log"
-	"time"
 
 	"github.com/ville6000/toggl-cli/internal/api"
+	"github.com/ville6000/toggl-cli/internal/utils"
 
 	"github.com/spf13/cobra"
 )
@@ -33,18 +32,7 @@ var startCmd = &cobra.Command{
 			}
 		}
 
-		timeEntry := api.TimeEntry{
-			CreatedWith: "toggl-cli",
-			Description: description,
-			Tags:        []string{},
-			Billable:    false,
-			WorkspaceID: workspaceId,
-			Duration:    -1,
-			Start:       time.Now().Format(time.RFC3339),
-			Stop:        nil,
-			ProjectID:   projectId,
-		}
-
+		timeEntry := client.NewTimeEntry(description, workspaceId, projectId, false)
 		_, err = client.CreateTimeEntry(workspaceId, timeEntry)
 		if err != nil {
 			log.Fatal("Failed to create time entry:", err)

--- a/cmd/workspaces.go
+++ b/cmd/workspaces.go
@@ -2,8 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/ville6000/toggl-cli/internal/utils"
 	"log"
+
+	"github.com/ville6000/toggl-cli/internal/utils"
 
 	"github.com/spf13/cobra"
 	"github.com/ville6000/toggl-cli/internal/api"

--- a/internal/api/toggl-service.go
+++ b/internal/api/toggl-service.go
@@ -54,6 +54,24 @@ func (c *Client) CreateTimeEntry(workspaceId int, entry TimeEntry) (*TimeEntry, 
 	return &createdEntry, nil
 }
 
+func (c *Client) NewTimeEntry(description string,
+	workspaceID int,
+	projectID int,
+	billable bool,
+) TimeEntry {
+	return TimeEntry{
+		CreatedWith: "toggl-cli",
+		Description: description,
+		Tags:        []string{},
+		Billable:    billable,
+		WorkspaceID: workspaceID,
+		Duration:    -1,
+		Start:       time.Now().Format(time.RFC3339),
+		Stop:        nil,
+		ProjectID:   projectID,
+	}
+}
+
 func (c *Client) StopTimeEntry(workspaceId int, entryId int) (*TimeEntryItem, error) {
 	endpoint := fmt.Sprintf("/workspaces/%d/time_entries/%d/stop", workspaceId, entryId)
 	req, err := c.newRequest(http.MethodPatch, endpoint, nil)

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -1,8 +1,9 @@
 package utils
 
 import (
-	"github.com/spf13/viper"
 	"log"
+
+	"github.com/spf13/viper"
 )
 
 func GetTogglConfig() (string, int) {


### PR DESCRIPTION
This pull request refactors the time entry creation logic in the Toggl CLI application to improve code reusability and maintainability. It introduces a new `NewTimeEntry` helper method in the `Client` struct and updates commands to use this method. Additionally, it includes minor import reordering for better readability.

### Refactoring of time entry creation:

* Added a new `NewTimeEntry` method in `internal/api/toggl-service.go` to encapsulate the creation of `TimeEntry` objects. This method standardizes the initialization of `TimeEntry` with default values such as `CreatedWith`, `Duration`, and `Start`.
* Updated the `continue` command in `cmd/continue.go` to use the new `NewTimeEntry` method, simplifying the logic for creating a time entry.
* Updated the `start` command in `cmd/start.go` to use the new `NewTimeEntry` method, reducing code duplication and improving clarity.

### Minor import reordering:

* Adjusted the order of imports in several files (`cmd/continue.go`, `cmd/projects.go`, `cmd/start.go`, `cmd/workspaces.go`, and `internal/utils/config.go`) to group standard, third-party, and local imports consistently. [[1]](diffhunk://#diff-c81692ce703f798f07159bea7fd272c8dd598cc9eb19762b29659cdfd6951cbcL5-R8) [[2]](diffhunk://#diff-e82952d2819fa0443c40e71a2fe089728d309318d933843449ff63d6ccd3ef2dL5-R8) [[3]](diffhunk://#diff-e3ad76770e5ac8ed654e8c5585782469e67e0d981adb9153604109263f22e93eL5-R8) [[4]](diffhunk://#diff-545d8e6066af5675e676207857197c7ab40384cc8acd2b5af49d4211828733f2L5-R8) [[5]](diffhunk://#diff-c9b3e003a0f51be64bfbda657de17393605ac1fad9d39f506be93501827cca93L4-R6)