### PR TITLE
feat: continue from nth time entry

### DIFF
--- a/cmd/continue.go
+++ b/cmd/continue.go
@@ -27,7 +27,12 @@ var continueCmd = &cobra.Command{
 			return
 		}
 
-		e := timeEntries[0]
+		index, err := cmd.Flags().GetInt("index")
+		if err != nil {
+			log.Fatal("Error retrieving index flag:", err)
+		}
+
+		e := timeEntries[index]
 		timeEntry := client.NewTimeEntry(e.Description,
 			workspaceId,
 			e.ProjectID,
@@ -44,4 +49,5 @@ var continueCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(continueCmd)
+	continueCmd.Flags().IntP("index", "i", 0, "Index of the time entry to continue")
 }


### PR DESCRIPTION
This pull request introduces a new feature to the `continue` command in the `cmd/continue.go` file, allowing users to specify the index of a time entry to continue. The most important changes include adding a new flag for the index and updating the logic to retrieve the specified time entry based on the provided index.

### Feature Addition: Index Flag for `continue` Command
* Added a new `--index` (`-i`) flag to the `continue` command, enabling users to specify which time entry to continue by its index. (`[cmd/continue.goR52](diffhunk://#diff-c81692ce703f798f07159bea7fd272c8dd598cc9eb19762b29659cdfd6951cbcR52)`)