### PR TITLE
feat: add command for start commands automatic project detection

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -93,7 +93,7 @@ func ConfigPath() (string, error) {
 		return filepath.Join(home, ".config", "toggl-cli", "config.yaml"), nil
 	}
 
-	return filepath.Join(home, ".toggle-cli.yaml"), nil
+	return filepath.Join(home, ".toggl-cli.yaml"), nil
 }
 
 func init() {

--- a/cmd/saveProjectConfig.go
+++ b/cmd/saveProjectConfig.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/viper"
+	"github.com/ville6000/toggl-cli/internal/api"
+	"github.com/ville6000/toggl-cli/internal/utils"
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var saveProjectConfigCmd = &cobra.Command{
+	Use:   "saveProjectConfig",
+	Short: "Save project path to be used with start command",
+	Long:  "",
+	Run: func(cmd *cobra.Command, args []string) {
+		token, workspaceId := utils.GetTogglConfig()
+		projectName := args[0]
+		currentPath, err := os.Getwd()
+		if err != nil {
+			fmt.Println("Error getting current path:", err)
+			return
+		}
+
+		client := api.NewAPIClient(token)
+
+		var projectId int
+		if projectName != "" {
+			projectId, err = client.GetProjectIdByName(workspaceId, projectName)
+			if err != nil {
+				log.Fatal("Failed to get project ID:", err)
+			}
+		}
+
+		viper.Set(fmt.Sprintf("projects.%s", projectName), projectId)
+		viper.Set(fmt.Sprintf("projects.%s.path", projectName), currentPath)
+		if err := viper.WriteConfig(); err != nil {
+			log.Fatal("Error saving configuration:", err)
+		}
+
+		fmt.Println("Configuration saved successfully!")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(saveProjectConfigCmd)
+}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -3,12 +3,18 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/ville6000/toggl-cli/internal/api"
 	"github.com/ville6000/toggl-cli/internal/utils"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
+
+type ProjectConfig struct {
+	Path string `mapstructure:"path"`
+}
 
 var startCmd = &cobra.Command{
 	Use:   "start",
@@ -23,13 +29,9 @@ var startCmd = &cobra.Command{
 		}
 
 		client := api.NewAPIClient(token)
-
-		var projectId int
-		if projectName != "" {
-			projectId, err = client.GetProjectIdByName(workspaceId, projectName)
-			if err != nil {
-				log.Fatal("Failed to get project ID:", err)
-			}
+		projectId, err := findProjectIdForEntry(projectName, client, workspaceId)
+		if err != nil {
+			log.Fatal("Failed to find project ID:", err)
 		}
 
 		timeEntry := client.NewTimeEntry(description, workspaceId, projectId, false)
@@ -46,5 +48,49 @@ func init() {
 	rootCmd.AddCommand(startCmd)
 
 	startCmd.Flags().StringP("project", "p", "", "Project for the time entry")
-	startCmd.MarkFlagRequired("project")
+}
+
+func findProjectIdForEntry(projectName string, client *api.Client, workspaceID int) (int, error) {
+	var projectId int
+	var err error
+
+	if projectName == "" {
+		currentPath, err := os.Getwd()
+		if err != nil {
+			return 0, fmt.Errorf("failed to get current working directory: %w", err)
+		}
+
+		projectName, err = findProjectNameFromConfig(currentPath)
+		if err != nil {
+			return 0, fmt.Errorf("failed to find project name from config: %w", err)
+		}
+	}
+
+	if projectName == "" {
+		return 0, fmt.Errorf("no project name provided and no matching project found in config for current path")
+	}
+
+	projectId, err = client.GetProjectIdByName(workspaceID, projectName)
+	if err != nil || projectId == 0 {
+		return 0, fmt.Errorf("failed to get project ID for '%s': %w", projectName, err)
+	}
+
+	fmt.Printf("Using project '%s' with ID %d for time entry\n", projectName, projectId)
+	return projectId, nil
+}
+
+func findProjectNameFromConfig(currentPath string) (string, error) {
+	var projects map[string]ProjectConfig
+	err := viper.UnmarshalKey("projects", &projects)
+	if err != nil {
+		return "", fmt.Errorf("failed to unmarshal projects from config: %w", err)
+	}
+
+	for name, p := range projects {
+		if p.Path == currentPath {
+			return name, nil
+		}
+	}
+
+	return "", fmt.Errorf("no matching project found for current path '%s'", currentPath)
 }


### PR DESCRIPTION
This pull request introduces enhancements to the `toggl-cli` command-line tool, focusing on configuration management and improving the user experience for project-based operations. The changes include fixing a typo in the configuration file path, adding a new command to save project configurations, and enhancing the `start` command to automatically detect project configurations based on the current directory.

### Configuration Management Enhancements:
* **Fixed typo in configuration file path**: Updated the default configuration file path from `.toggle-cli.yaml` to `.toggl-cli.yaml` in the `ConfigPath` function. (`cmd/config.go`, [cmd/config.goL96-R96](diffhunk://#diff-c5694d4d0b3b030b84de1d8ea8af2a43dc7b8598525d50a734c100ac22b5fdaaL96-R96))
* **Added `saveProjectConfig` command**: Introduced a new command that allows users to save project-specific configurations, including mapping project names to IDs and associating them with filesystem paths. (`cmd/saveProjectConfig.go`, [cmd/saveProjectConfig.goR1-R49](diffhunk://#diff-30e0876797296a7b07bfe758a31a402395ccf3e20d74af5e805a532a2aafcbeaR1-R49))

### Improvements to `start` Command:
* **Refactored project ID retrieval**: Replaced inline logic for retrieving project IDs with a new helper function, `findProjectIdForEntry`, which supports automatic detection of project configurations based on the current working directory. (`cmd/start.go`, [[1]](diffhunk://#diff-e3ad76770e5ac8ed654e8c5585782469e67e0d981adb9153604109263f22e93eL26-R34) [[2]](diffhunk://#diff-e3ad76770e5ac8ed654e8c5585782469e67e0d981adb9153604109263f22e93eL49-R95)
* **Added support for project path-based detection**: Implemented `findProjectNameFromConfig`, which retrieves the project name from the configuration file based on the current directory, enabling seamless project selection without requiring manual input. (`cmd/start.go`, [cmd/start.goL49-R95](diffhunk://#diff-e3ad76770e5ac8ed654e8c5585782469e67e0d981adb9153604109263f22e93eL49-R95))
* **Removed mandatory project flag**: The `start` command no longer requires the `--project` flag, as it can now automatically determine the project based on the saved configuration. (`cmd/start.go`, [cmd/start.goL49-R95](diffhunk://#diff-e3ad76770e5ac8ed654e8c5585782469e67e0d981adb9153604109263f22e93eL49-R95))