### PR TITLE
Cache projects

### DIFF
--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -43,3 +43,8 @@ type Project struct {
 	ID   int    `json:"id"`
 	Name string `json:"name"`
 }
+
+type ProjectCache struct {
+	Timestamp time.Time `json:"timestamp"`
+	Data      []Project `json:"data"`
+}


### PR DESCRIPTION
This pull request introduces caching for project data in the Toggl API client to improve performance and reduce redundant API calls. The most significant changes include adding a new `ProjectCache` struct, implementing caching logic in the `GetProjects` method, and creating helper functions for reading from and writing to the cache.

### Caching functionality:

* **Added `ProjectCache` struct**: A new struct, `ProjectCache`, was added to store project data along with a timestamp for cache validation. (`internal/api/models.go`, [internal/api/models.goR46-R50](diffhunk://#diff-036e333f496af089114bd0885373cae1795fe46d172a7bb6477d5f57976304edR46-R50))

* **Integrated caching in `GetProjects` method**: The `GetProjects` method now attempts to retrieve cached project data using the `getProjectsFromCache` function before making an API call. If the cache is valid, it returns the cached data; otherwise, it fetches fresh data and saves it to the cache using `saveProjectsToCache`. (`internal/api/toggl-service.go`, [[1]](diffhunk://#diff-87123d7ab29266afa182f24e93948104d31e94bca9ceb0bf3490288c88865536R95-R99) [[2]](diffhunk://#diff-87123d7ab29266afa182f24e93948104d31e94bca9ceb0bf3490288c88865536R111-R112)

* **Implemented cache helper functions**:
  - `getProjectsFromCache`: Reads cached project data from a file and validates its freshness.
  - `getCachePath`: Constructs the cache file path using the workspace ID.
  - [`saveProjectsToCache`](diffhunk://#diff-87123d7ab29266afa182f24e93948104d31e94bca9ceb0bf3490288c88865536R225-R290): Saves project data to a cache file in JSON format. (`internal/api/toggl-service.go`, [internal/api/toggl-service.goR225-R290](diffhunk://#diff-87123d7ab29266afa182f24e93948104d31e94bca9ceb0bf3490288c88865536R225-R290))
