### PR TITLE
tidy: defragment description handling

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -23,13 +23,7 @@ var startCmd = &cobra.Command{
 	Short: "Start a new time entry",
 	Long:  "",
 	Run: func(cmd *cobra.Command, args []string) {
-		var description string
 		token, workspaceId := utils.GetTogglConfig()
-
-		if args != nil && len(args) > 0 {
-			description = args[0]
-		}
-
 		projectName, err := cmd.Flags().GetString("project")
 		if err != nil {
 			log.Fatal("Error retrieving project flag:", err)
@@ -41,10 +35,7 @@ var startCmd = &cobra.Command{
 			log.Fatal("Failed to find project ID:", err)
 		}
 
-		if description == "" {
-			description = detectDescriptionFromCurrentPath()
-		}
-
+		description := getDescription(args)
 		timeEntry := client.NewTimeEntry(description, workspaceId, projectId, false)
 		_, err = client.CreateTimeEntry(workspaceId, timeEntry)
 		if err != nil {
@@ -108,6 +99,20 @@ func findProjectNameFromConfig(currentPath string) (string, error) {
 	}
 
 	return "", fmt.Errorf("no matching project found for current path '%s'", currentPath)
+}
+
+func getDescription(args []string) string {
+	var description string
+
+	if args != nil && len(args) > 0 {
+		description = args[0]
+	}
+
+	if description == "" {
+		description = detectDescriptionFromCurrentPath()
+	}
+
+	return description
 }
 
 func detectDescriptionFromCurrentPath() string {


### PR DESCRIPTION
This pull request refactors the handling of the `description` variable in the `start` command to improve code readability and maintainability. The logic for determining the description has been extracted into a new helper function, `getDescription`.

### Refactoring for improved readability:

* [`cmd/start.go`](diffhunk://#diff-e3ad76770e5ac8ed654e8c5585782469e67e0d981adb9153604109263f22e93eL26-L32): Removed inline logic for determining the `description` variable and replaced it with a call to the new `getDescription` function. This simplifies the `Run` function of the `start` command. [[1]](diffhunk://#diff-e3ad76770e5ac8ed654e8c5585782469e67e0d981adb9153604109263f22e93eL26-L32) [[2]](diffhunk://#diff-e3ad76770e5ac8ed654e8c5585782469e67e0d981adb9153604109263f22e93eL44-R38)
* [`cmd/start.go`](diffhunk://#diff-e3ad76770e5ac8ed654e8c5585782469e67e0d981adb9153604109263f22e93eR104-R117): Added a new helper function, `getDescription`, which encapsulates the logic for setting the `description` based on command-line arguments or the current path.