### PR TITLE
Add 7pace sync command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,25 @@ toggl:
 The configuration can be generated using the `toggl-cli config` command.
 The token can be obtained from the Toggl website.
 
+### 7pace Timetracker (optional)
+
+To post worklogs to an on-prem 7pace Timetracker instance, add a `sevenpace`
+section to the config (also prompted for by `toggl-cli config`):
+
+```yaml
+sevenpace:
+  base_url: https://timetracker.example.com:8090/api/YourCollection/rest
+  domain: CORP
+  username: <windows_username>
+  password: <windows_password>
+  activity_type_id: <optional_activity_type_uuid>
+  insecure_skip_verify: false # set true only for self-signed corp certs
+```
+
+The on-prem 7pace REST API uses NTLM (Windows) authentication, so the domain
+username and password are stored in the config file **in plaintext**. Reaching
+the instance also requires being on the corporate network / VPN.
+
 ## Commands
 
 - `toggl-cli workspaces` - List all workspaces
@@ -24,3 +43,27 @@ The token can be obtained from the Toggl website.
 - `toggl-cli projects` - List projects
 - `toggl-cli www` - Open the Toggl website
 - `toggl-cli config` - Generate config for the CLI tool
+- `toggl-cli 7pace sync` - Post Toggl entries for a date range to 7pace as worklogs
+- `toggl-cli 7pace add` - Post a single worklog to 7pace
+
+### 7pace worklogs
+
+`toggl-cli 7pace sync` fetches your Toggl entries and posts each one to 7pace.
+The Azure DevOps work item id is parsed from the entry description (e.g.
+`#1234 fix bug`, `AB#1234 ...`, or a leading `1234 - ...`); entries without a
+work item id are skipped and reported. It accepts the same date flags as
+`history` (`--week`, `--month`, `--start`, `--end`).
+
+There is **no de-duplication** — re-running the same range creates duplicate
+worklogs. Always preview first with `--dry-run`:
+
+```sh
+toggl-cli 7pace sync --week --dry-run   # preview
+toggl-cli 7pace sync --week             # post (asks for confirmation)
+```
+
+`toggl-cli 7pace add` posts a one-off worklog:
+
+```sh
+toggl-cli 7pace add --work-item 1234 --duration 1h30m --comment "code review"
+```

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -50,7 +50,12 @@ var configCmd = &cobra.Command{
 			}
 		}
 
-		if err = writeConfig(token, workspaceID, tz); err != nil {
+		sp, err := readSevenPaceInput(reader)
+		if err != nil {
+			return err
+		}
+
+		if err = writeConfig(token, workspaceID, tz, sp); err != nil {
 			return fmt.Errorf("error saving configuration: %w", err)
 		}
 
@@ -59,7 +64,59 @@ var configCmd = &cobra.Command{
 	},
 }
 
-func writeConfig(token string, workspaceID int, timezone string) error {
+// sevenPaceInput holds the optional on-prem 7pace Timetracker settings gathered
+// during interactive configuration.
+type sevenPaceInput struct {
+	baseURL        string
+	domain         string
+	username       string
+	password       string
+	activityTypeID string
+}
+
+// readSevenPaceInput prompts for the optional 7pace settings. Leaving the base
+// URL empty skips 7pace configuration entirely.
+//
+// Note: the password is stored in plaintext in the config file — this is the
+// tradeoff of using NTLM credentials from config.
+func readSevenPaceInput(reader *bufio.Reader) (sevenPaceInput, error) {
+	fmt.Print("Configure 7pace Timetracker? Enter base URL (leave empty to skip): ")
+	baseURL, err := reader.ReadString('\n')
+	if err != nil {
+		return sevenPaceInput{}, fmt.Errorf("error reading input: %w", err)
+	}
+	baseURL = strings.TrimSpace(baseURL)
+	if baseURL == "" {
+		return sevenPaceInput{}, nil
+	}
+
+	prompt := func(label string) (string, error) {
+		fmt.Print(label)
+		line, readErr := reader.ReadString('\n')
+		if readErr != nil {
+			return "", fmt.Errorf("error reading input: %w", readErr)
+		}
+		return strings.TrimSpace(line), nil
+	}
+
+	sp := sevenPaceInput{baseURL: baseURL}
+	if sp.domain, err = prompt("Windows domain (leave empty if none): "); err != nil {
+		return sevenPaceInput{}, err
+	}
+	if sp.username, err = prompt("Windows username: "); err != nil {
+		return sevenPaceInput{}, err
+	}
+	if sp.password, err = prompt("Windows password (stored in plaintext): "); err != nil {
+		return sevenPaceInput{}, err
+	}
+	if sp.activityTypeID, err = prompt("Activity type UUID (optional): "); err != nil {
+		return sevenPaceInput{}, err
+	}
+
+	return sp, nil
+}
+
+func writeConfig(token string, workspaceID int, timezone string, sp sevenPaceInput) error {
 	configPath, err := ConfigPath()
 	if err != nil {
 		return fmt.Errorf("failed to get config path: %w", err)
@@ -69,6 +126,14 @@ func writeConfig(token string, workspaceID int, timezone string) error {
 	viper.Set("toggl.token", token)
 	viper.Set("toggl.workspace_id", workspaceID)
 	viper.Set("toggl.timezone", timezone)
+
+	if sp.baseURL != "" {
+		viper.Set("sevenpace.base_url", sp.baseURL)
+		viper.Set("sevenpace.domain", sp.domain)
+		viper.Set("sevenpace.username", sp.username)
+		viper.Set("sevenpace.password", sp.password)
+		viper.Set("sevenpace.activity_type_id", sp.activityTypeID)
+	}
 
 	writeErr := viper.WriteConfig()
 

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -192,6 +192,19 @@ func getSortedTimeEntryDates(groupedEntries map[string][]data.TimeEntryItem) []s
 }
 
 func getDateParams(cmd *cobra.Command) (time.Time, time.Time, error) {
+	// --today is optional and only defined on some commands; it is also the
+	// default range when no date flags are given.
+	if cmd.Flags().Lookup("today") != nil {
+		today, err := cmd.Flags().GetBool("today")
+		if err != nil {
+			return time.Time{}, time.Time{}, fmt.Errorf("failed to get today flag: %w", err)
+		}
+		if today {
+			start := time.Now()
+			return start, start.AddDate(0, 0, 1), nil
+		}
+	}
+
 	week, err := cmd.Flags().GetBool("week")
 	if err != nil {
 		return time.Time{}, time.Time{}, fmt.Errorf("failed to get week flag: %w", err)

--- a/cmd/sevenpace.go
+++ b/cmd/sevenpace.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/ville6000/toggl-cli/internal/data"
+)
+
+// sevenpaceCmd is the parent command for posting worklogs to an on-prem 7pace
+// Timetracker instance.
+//
+// Note: 7pace credentials (domain, username, password) are stored in plaintext
+// in the config file. The `sync` command performs no de-duplication, so
+// re-running the same date range will create duplicate worklogs — use
+// `--dry-run` first to preview.
+var sevenpaceCmd = &cobra.Command{
+	Use:   "7pace",
+	Short: "Post worklogs to 7pace Timetracker",
+	Long:  "Post worklogs to an on-prem 7pace Timetracker instance from your Toggl time entries.",
+}
+
+var (
+	workItemHashRe    = regexp.MustCompile(`#(\d+)`)
+	workItemLeadingRe = regexp.MustCompile(`^\s*(\d+)`)
+)
+
+// parseWorkItemID extracts an Azure DevOps work item id from a Toggl entry
+// description. It prefers a `#1234` style reference (e.g. `AB#1234`) and falls
+// back to a leading number (e.g. `1234 - do stuff`). Returns false when no id
+// can be found.
+func parseWorkItemID(description string) (int, bool) {
+	if m := workItemHashRe.FindStringSubmatch(description); m != nil {
+		id, err := strconv.Atoi(m[1])
+		if err == nil {
+			return id, true
+		}
+	}
+	if m := workItemLeadingRe.FindStringSubmatch(description); m != nil {
+		id, err := strconv.Atoi(m[1])
+		if err == nil {
+			return id, true
+		}
+	}
+	return 0, false
+}
+
+// toWorkLog maps a Toggl time entry to a 7pace worklog. The bool return
+// reports whether a work item id was found in the description.
+func toWorkLog(entry data.TimeEntryItem, activityTypeID string, location *time.Location) (data.SevenPaceWorkLog, bool) {
+	id, ok := parseWorkItemID(entry.Description)
+
+	workLog := data.SevenPaceWorkLog{
+		Timestamp: entry.Start.In(location).Format(time.RFC3339),
+		Length:    entry.Duration,
+		Comment:   entry.Description,
+	}
+
+	if ok {
+		workLog.WorkItemID = &id
+	}
+
+	if activityTypeID != "" {
+		workLog.ActivityType = &data.SevenPaceActivityRef{ID: activityTypeID}
+	}
+
+	return workLog, ok
+}
+
+func init() {
+	rootCmd.AddCommand(sevenpaceCmd)
+}

--- a/cmd/sevenpace_add.go
+++ b/cmd/sevenpace_add.go
@@ -1,0 +1,141 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/ville6000/toggl-cli/internal/api"
+	"github.com/ville6000/toggl-cli/internal/data"
+	"github.com/ville6000/toggl-cli/internal/utils"
+)
+
+var sevenpaceAddCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Post a single worklog to 7pace",
+	Long: "Post a single worklog to 7pace Timetracker. A worklog must have either a work item id\n" +
+		"or a comment, and a duration greater than zero.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		spCfg, err := utils.GetSevenPaceConfig()
+		if err != nil {
+			return err
+		}
+
+		location, err := utils.GetTimezone()
+		if err != nil {
+			return err
+		}
+
+		workItem, err := cmd.Flags().GetInt("work-item")
+		if err != nil {
+			return fmt.Errorf("failed to get work-item flag: %w", err)
+		}
+
+		comment, err := cmd.Flags().GetString("comment")
+		if err != nil {
+			return fmt.Errorf("failed to get comment flag: %w", err)
+		}
+
+		durationStr, err := cmd.Flags().GetString("duration")
+		if err != nil {
+			return fmt.Errorf("failed to get duration flag: %w", err)
+		}
+
+		dateStr, err := cmd.Flags().GetString("date")
+		if err != nil {
+			return fmt.Errorf("failed to get date flag: %w", err)
+		}
+
+		activityType, err := cmd.Flags().GetString("activity-type")
+		if err != nil {
+			return fmt.Errorf("failed to get activity-type flag: %w", err)
+		}
+
+		length, err := parseDurationSeconds(durationStr)
+		if err != nil {
+			return err
+		}
+		if length <= 0 {
+			return fmt.Errorf("--duration must be greater than zero")
+		}
+
+		if workItem == 0 && comment == "" {
+			return fmt.Errorf("a worklog must have either --work-item or --comment")
+		}
+
+		timestamp, err := parseWorkLogDate(dateStr, location)
+		if err != nil {
+			return err
+		}
+
+		if activityType == "" {
+			activityType = spCfg.ActivityTypeID
+		}
+
+		workLog := data.SevenPaceWorkLog{
+			Timestamp: timestamp.Format(time.RFC3339),
+			Length:    length,
+			Comment:   comment,
+		}
+		if workItem != 0 {
+			workLog.WorkItemID = &workItem
+		}
+		if activityType != "" {
+			workLog.ActivityType = &data.SevenPaceActivityRef{ID: activityType}
+		}
+
+		spClient := api.NewSevenPaceClient(spCfg)
+		if _, err := spClient.CreateWorkLog(workLog); err != nil {
+			return fmt.Errorf("failed to create worklog: %w", err)
+		}
+
+		fmt.Printf("Posted worklog: %s for %s\n", api.FormatDuration(float64(length)), timestamp.Format("2006-01-02 15:04"))
+		return nil
+	},
+}
+
+// parseDurationSeconds accepts a Go duration string (e.g. "1h30m") or a plain
+// number of seconds and returns the duration in seconds.
+func parseDurationSeconds(value string) (int, error) {
+	if value == "" {
+		return 0, fmt.Errorf("--duration is required")
+	}
+
+	if d, err := time.ParseDuration(value); err == nil {
+		return int(d.Seconds()), nil
+	}
+
+	seconds, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid --duration %q: use e.g. 1h30m or a number of seconds", value)
+	}
+
+	return seconds, nil
+}
+
+// parseWorkLogDate parses the --date flag in the given location, accepting
+// either "YYYY-MM-DD HH:MM" or "YYYY-MM-DD". An empty value defaults to now.
+func parseWorkLogDate(value string, location *time.Location) (time.Time, error) {
+	if value == "" {
+		return time.Now().In(location), nil
+	}
+
+	for _, layout := range []string{"2006-01-02 15:04", "2006-01-02"} {
+		if t, err := time.ParseInLocation(layout, value, location); err == nil {
+			return t, nil
+		}
+	}
+
+	return time.Time{}, fmt.Errorf("invalid --date %q: use YYYY-MM-DD or \"YYYY-MM-DD HH:MM\"", value)
+}
+
+func init() {
+	sevenpaceCmd.AddCommand(sevenpaceAddCmd)
+
+	sevenpaceAddCmd.Flags().Int("work-item", 0, "Azure DevOps work item id")
+	sevenpaceAddCmd.Flags().String("comment", "", "Worklog comment")
+	sevenpaceAddCmd.Flags().String("duration", "", "Duration, e.g. 1h30m or a number of seconds")
+	sevenpaceAddCmd.Flags().String("date", "", "Date/time of the worklog: YYYY-MM-DD or \"YYYY-MM-DD HH:MM\" (default now)")
+	sevenpaceAddCmd.Flags().String("activity-type", "", "Activity type UUID (overrides config)")
+}

--- a/cmd/sevenpace_sync.go
+++ b/cmd/sevenpace_sync.go
@@ -1,0 +1,169 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/ville6000/toggl-cli/internal/api"
+	"github.com/ville6000/toggl-cli/internal/data"
+	"github.com/ville6000/toggl-cli/internal/utils"
+)
+
+// plannedWorkLog pairs a built 7pace payload with the display columns used in
+// the preview / result tables.
+type plannedWorkLog struct {
+	workItem string
+	started  string
+	duration string
+	comment  string
+	payload  data.SevenPaceWorkLog
+}
+
+var sevenpaceSyncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Sync Toggl time entries to 7pace as worklogs",
+	Long: "Fetch Toggl time entries for a date range and post each one to 7pace as a worklog.\n" +
+		"The work item id is parsed from the entry description (e.g. \"#1234\" or a leading number);\n" +
+		"entries without a work item id are skipped. There is no de-duplication, so re-running the\n" +
+		"same range creates duplicate worklogs — use --dry-run first to preview.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		token, _, err := utils.GetConfig()
+		if err != nil {
+			return fmt.Errorf("failed to get configuration: %w", err)
+		}
+
+		spCfg, err := utils.GetSevenPaceConfig()
+		if err != nil {
+			return err
+		}
+
+		location, err := utils.GetTimezone()
+		if err != nil {
+			return err
+		}
+
+		dryRun, err := cmd.Flags().GetBool("dry-run")
+		if err != nil {
+			return fmt.Errorf("failed to get dry-run flag: %w", err)
+		}
+
+		assumeYes, err := cmd.Flags().GetBool("yes")
+		if err != nil {
+			return fmt.Errorf("failed to get yes flag: %w", err)
+		}
+
+		startTime, endTime, err := getDateParams(cmd)
+		if err != nil {
+			return err
+		}
+
+		client := api.NewAPIClient(token)
+		timeEntries, err := client.GetHistory(&startTime, &endTime)
+		if err != nil {
+			return fmt.Errorf("failed to get history: %w", err)
+		}
+
+		var planned []plannedWorkLog
+		var skipped [][]interface{}
+		for _, entry := range timeEntries {
+			if entry.Duration <= 0 {
+				continue // skip running or zero-length entries
+			}
+
+			workLog, ok := toWorkLog(entry, spCfg.ActivityTypeID, location)
+			started := entry.Start.In(location).Format("2006-01-02 15:04")
+			duration := api.FormatDuration(float64(entry.Duration))
+
+			if !ok {
+				skipped = append(skipped, []interface{}{"—", started, duration, entry.Description})
+				continue
+			}
+
+			planned = append(planned, plannedWorkLog{
+				workItem: fmt.Sprintf("%d", *workLog.WorkItemID),
+				started:  started,
+				duration: duration,
+				comment:  entry.Description,
+				payload:  workLog,
+			})
+		}
+
+		if len(planned) == 0 && len(skipped) == 0 {
+			return fmt.Errorf("no time entries found for the specified date range")
+		}
+
+		headers := []interface{}{"Work Item", "Started At", "Duration", "Comment"}
+		if len(planned) > 0 {
+			rows := make([][]interface{}, 0, len(planned))
+			for _, p := range planned {
+				rows = append(rows, []interface{}{p.workItem, p.started, p.duration, p.comment})
+			}
+			utils.RenderTable("Worklogs to post", headers, rows, nil)
+			fmt.Println()
+		}
+		if len(skipped) > 0 {
+			utils.RenderTable("Skipped (no work item id)", headers, skipped, nil)
+			fmt.Println()
+		}
+
+		if dryRun {
+			fmt.Printf("Dry run: %d worklog(s) would be posted, %d skipped.\n", len(planned), len(skipped))
+			return nil
+		}
+
+		if len(planned) == 0 {
+			fmt.Println("Nothing to post.")
+			return nil
+		}
+
+		if !assumeYes && !confirm(fmt.Sprintf("Post %d worklog(s) to 7pace?", len(planned))) {
+			fmt.Println("Aborted.")
+			return nil
+		}
+
+		spClient := api.NewSevenPaceClient(spCfg)
+		posted := 0
+		var failures [][]interface{}
+		for _, p := range planned {
+			if _, postErr := spClient.CreateWorkLog(p.payload); postErr != nil {
+				failures = append(failures, []interface{}{p.workItem, p.started, p.duration, postErr.Error()})
+				continue
+			}
+			posted++
+		}
+
+		fmt.Printf("Posted %d worklog(s), %d skipped, %d failed.\n", posted, len(skipped), len(failures))
+		if len(failures) > 0 {
+			utils.RenderTable("Failed", []interface{}{"Work Item", "Started At", "Duration", "Error"}, failures, nil)
+			return fmt.Errorf("%d worklog(s) failed to post", len(failures))
+		}
+
+		return nil
+	},
+}
+
+func confirm(prompt string) bool {
+	fmt.Printf("%s [y/N]: ", prompt)
+	reader := bufio.NewReader(os.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	return answer == "y" || answer == "yes"
+}
+
+func init() {
+	sevenpaceCmd.AddCommand(sevenpaceSyncCmd)
+
+	sevenpaceSyncCmd.Flags().BoolP("today", "t", false, "Sync only today's entries (default when no date flags are given)")
+	sevenpaceSyncCmd.Flags().BoolP("week", "w", false, "Sync entries for the current week")
+	sevenpaceSyncCmd.Flags().BoolP("month", "m", false, "Sync entries for the current month")
+	sevenpaceSyncCmd.Flags().StringP("start", "s", "", "Start date, format: YYYY-MM-DD")
+	sevenpaceSyncCmd.Flags().StringP("end", "e", "", "End date, format: YYYY-MM-DD")
+	sevenpaceSyncCmd.Flags().Bool("dry-run", false, "Preview the worklogs without posting")
+	sevenpaceSyncCmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt")
+}

--- a/cmd/sevenpace_test.go
+++ b/cmd/sevenpace_test.go
@@ -1,0 +1,106 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ville6000/toggl-cli/internal/data"
+)
+
+func TestParseWorkItemID(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+		wantID      int
+		wantOK      bool
+	}{
+		{"hash prefix", "#1234 fix bug", 1234, true},
+		{"project hash", "AB#5678 do stuff", 5678, true},
+		{"leading number", "1234 - implement feature", 1234, true},
+		{"leading number with spaces", "  42 something", 42, true},
+		{"no id", "just some work", 0, false},
+		{"trailing number only", "work on ticket 99", 0, false},
+		{"empty", "", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotID, gotOK := parseWorkItemID(tt.description)
+			if gotID != tt.wantID || gotOK != tt.wantOK {
+				t.Errorf("parseWorkItemID(%q) = (%d, %v), want (%d, %v)", tt.description, gotID, gotOK, tt.wantID, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestToWorkLog_WithWorkItem(t *testing.T) {
+	start := time.Date(2024, 1, 2, 10, 30, 0, 0, time.UTC)
+	entry := data.TimeEntryItem{
+		Description: "#1234 build the thing",
+		Duration:    3600,
+		Start:       start,
+	}
+
+	wl, ok := toWorkLog(entry, "activity-uuid", time.UTC)
+	if !ok {
+		t.Fatal("expected ok=true for entry with work item id")
+	}
+	if wl.WorkItemID == nil || *wl.WorkItemID != 1234 {
+		t.Errorf("WorkItemID: got %v, want 1234", wl.WorkItemID)
+	}
+	if wl.Length != 3600 {
+		t.Errorf("Length: got %d, want 3600 (seconds)", wl.Length)
+	}
+	if wl.Comment != "#1234 build the thing" {
+		t.Errorf("Comment: got %q", wl.Comment)
+	}
+	if wl.Timestamp != "2024-01-02T10:30:00Z" {
+		t.Errorf("Timestamp: got %q, want RFC3339", wl.Timestamp)
+	}
+	if wl.ActivityType == nil || wl.ActivityType.ID != "activity-uuid" {
+		t.Errorf("ActivityType: got %v", wl.ActivityType)
+	}
+}
+
+func TestToWorkLog_NoWorkItem(t *testing.T) {
+	entry := data.TimeEntryItem{
+		Description: "misc work",
+		Duration:    1800,
+		Start:       time.Date(2024, 3, 4, 9, 0, 0, 0, time.UTC),
+	}
+
+	wl, ok := toWorkLog(entry, "", time.UTC)
+	if ok {
+		t.Error("expected ok=false when no work item id present")
+	}
+	if wl.WorkItemID != nil {
+		t.Errorf("WorkItemID: expected nil, got %v", wl.WorkItemID)
+	}
+	if wl.ActivityType != nil {
+		t.Errorf("ActivityType: expected nil when no activity configured, got %v", wl.ActivityType)
+	}
+}
+
+func TestParseDurationSeconds(t *testing.T) {
+	tests := []struct {
+		value   string
+		want    int
+		wantErr bool
+	}{
+		{"1h30m", 5400, false},
+		{"45m", 2700, false},
+		{"3600", 3600, false},
+		{"", 0, true},
+		{"abc", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			got, err := parseDurationSeconds(tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseDurationSeconds(%q) error = %v, wantErr %v", tt.value, err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("parseDurationSeconds(%q) = %d, want %d", tt.value, got, tt.want)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ville6000/toggl-cli
 go 1.26.1
 
 require (
+	github.com/Azure/go-ntlmssp v0.1.1
 	github.com/jedib0t/go-pretty/v6 v6.8.1
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Azure/go-ntlmssp v0.1.1 h1:l+FM/EEMb0U9QZE7mKNEDw5Mu3mFiaa2GKOoTSsNDPw=
+github.com/Azure/go-ntlmssp v0.1.1/go.mod h1:NYqdhxd/8aAct/s4qSYZEerdPuH1liG2/X9DiVTbhpk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/api/sevenpace-client.go
+++ b/internal/api/sevenpace-client.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"crypto/tls"
+	"net/http"
+	"time"
+
+	"github.com/Azure/go-ntlmssp"
+	"github.com/ville6000/toggl-cli/internal/utils"
+)
+
+// SevenPaceClient talks to an on-prem 7pace Timetracker REST API using NTLM
+// (Windows/Negotiate) authentication.
+type SevenPaceClient struct {
+	BaseURL        string
+	HTTPClient     *http.Client
+	Domain         string
+	Username       string
+	Password       string
+	ActivityTypeID string
+}
+
+// NewSevenPaceClient builds a client from the given 7pace configuration. The
+// HTTP transport is wrapped with an NTLM negotiator so that Basic-auth
+// credentials set on each request are used to perform the NTLM handshake.
+func NewSevenPaceClient(cfg utils.SevenPaceConfig) *SevenPaceClient {
+	// Force HTTP/1.1: NTLM authenticates a TCP connection, which does not work
+	// over HTTP/2's multiplexed connections. Setting TLSNextProto to a non-nil
+	// empty map disables the automatic HTTP/2 upgrade.
+	transport := &http.Transport{
+		TLSNextProto: map[string]func(authority string, c *tls.Conn) http.RoundTripper{},
+	}
+	if cfg.InsecureSkipTLS {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402 - opt-in for self-signed corp certs
+	}
+
+	return &SevenPaceClient{
+		BaseURL: cfg.BaseURL,
+		HTTPClient: &http.Client{
+			Timeout:   30 * time.Second,
+			Transport: ntlmssp.Negotiator{RoundTripper: transport},
+		},
+		Domain:         cfg.Domain,
+		Username:       cfg.Username,
+		Password:       cfg.Password,
+		ActivityTypeID: cfg.ActivityTypeID,
+	}
+}

--- a/internal/api/sevenpace-service.go
+++ b/internal/api/sevenpace-service.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/ville6000/toggl-cli/internal/data"
+)
+
+// CreateWorkLog posts a single worklog to 7pace Timetracker.
+func (c *SevenPaceClient) CreateWorkLog(workLog data.SevenPaceWorkLog) (*data.SevenPaceWorkLog, error) {
+	req, err := c.newRequest(http.MethodPost, "/workLogs?api-version=3.0", workLog)
+	if err != nil {
+		return nil, err
+	}
+
+	var created data.SevenPaceWorkLog
+	if reqErr := c.doRequest(req, http.StatusOK, &created); reqErr != nil {
+		return nil, reqErr
+	}
+
+	return &created, nil
+}
+
+func (c *SevenPaceClient) newRequest(method, endpoint string, body any) (*http.Request, error) {
+	var buf io.Reader
+	if body != nil {
+		jsonData, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		buf = bytes.NewBuffer(jsonData)
+	}
+
+	req, err := http.NewRequest(method, c.BaseURL+endpoint, buf)
+	if err != nil {
+		return nil, err
+	}
+
+	c.setDefaultRequestHeaders(req)
+
+	return req, nil
+}
+
+func (c *SevenPaceClient) doRequest(req *http.Request, expectedStatus int, result any) error {
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			log.Printf("failed to close response body: %v", closeErr)
+		}
+	}()
+
+	if resp.StatusCode != expectedStatus {
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode == http.StatusUnauthorized {
+			return fmt.Errorf("request failed: %s (server auth schemes: %q): %s\n"+
+				"check sevenpace.domain/username/password in your config; the Windows credentials were rejected",
+				resp.Status, resp.Header.Get("WWW-Authenticate"), strings.TrimSpace(string(body)))
+		}
+		return fmt.Errorf("request failed: %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+
+	if result != nil {
+		return json.NewDecoder(resp.Body).Decode(result)
+	}
+
+	return nil
+}
+
+// setDefaultRequestHeaders sets the Basic-auth credentials that the NTLM
+// negotiator uses for the handshake. The username is qualified with the domain
+// (DOMAIN\user) when a domain is configured.
+func (c *SevenPaceClient) setDefaultRequestHeaders(req *http.Request) {
+	user := c.Username
+	if c.Domain != "" {
+		user = c.Domain + "\\" + c.Username
+	}
+
+	req.SetBasicAuth(user, c.Password)
+	req.Header.Set("Content-Type", "application/json")
+}

--- a/internal/api/sevenpace_service_test.go
+++ b/internal/api/sevenpace_service_test.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ville6000/toggl-cli/internal/data"
+)
+
+// newTestSevenPaceClient creates a SevenPaceClient pointing at the test server,
+// bypassing the NTLM negotiator (which is only exercised against a real server).
+func newTestSevenPaceClient(t *testing.T, handler http.Handler) *SevenPaceClient {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	return &SevenPaceClient{
+		BaseURL:    server.URL,
+		HTTPClient: server.Client(),
+		Domain:     "CORP",
+		Username:   "user",
+		Password:   "secret",
+	}
+}
+
+func TestCreateWorkLog_PostsToEndpoint(t *testing.T) {
+	var capturedMethod, capturedPath, capturedQuery, capturedAuth string
+	var capturedBody data.SevenPaceWorkLog
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		capturedPath = r.URL.Path
+		capturedQuery = r.URL.RawQuery
+		capturedAuth = r.Header.Get("Authorization")
+
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &capturedBody); err != nil {
+			t.Errorf("unmarshal body: %v", err)
+		}
+
+		if err := json.NewEncoder(w).Encode(capturedBody); err != nil {
+			t.Errorf("encode: %v", err)
+		}
+	})
+	client := newTestSevenPaceClient(t, handler)
+
+	workItem := 1234
+	input := data.SevenPaceWorkLog{
+		Timestamp:  "2024-01-02T10:00:00Z",
+		Length:     3600,
+		WorkItemID: &workItem,
+		Comment:    "#1234 do stuff",
+	}
+
+	got, err := client.CreateWorkLog(input)
+	if err != nil {
+		t.Fatalf("CreateWorkLog: %v", err)
+	}
+
+	if capturedMethod != http.MethodPost {
+		t.Errorf("method: got %s, want POST", capturedMethod)
+	}
+	if capturedPath != "/workLogs" {
+		t.Errorf("path: got %q, want /workLogs", capturedPath)
+	}
+	if capturedQuery != "api-version=3.0" {
+		t.Errorf("query: got %q, want api-version=3.0", capturedQuery)
+	}
+	if capturedAuth == "" {
+		t.Error("expected Basic auth header to be set for NTLM negotiation")
+	}
+	if capturedBody.Length != 3600 || capturedBody.WorkItemID == nil || *capturedBody.WorkItemID != 1234 {
+		t.Errorf("unexpected body: %+v", capturedBody)
+	}
+	if got.Comment != "#1234 do stuff" {
+		t.Errorf("response comment: got %q", got.Comment)
+	}
+}
+
+func TestCreateWorkLog_HTTPError(t *testing.T) {
+	client := newTestSevenPaceClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+
+	if _, err := client.CreateWorkLog(data.SevenPaceWorkLog{Length: 3600}); err == nil {
+		t.Error("expected error for HTTP 400")
+	}
+}

--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -49,3 +49,18 @@ type ProjectCache struct {
 	Timestamp time.Time `json:"timestamp"`
 	Data      []Project `json:"data"`
 }
+
+// SevenPaceWorkLog is the request/response body for the 7pace Timetracker
+// REST worklog endpoint. Length is in seconds. A worklog must have either a
+// comment or an associated work item, and Length must be greater than 0.
+type SevenPaceWorkLog struct {
+	Timestamp    string                `json:"timestamp"`
+	Length       int                   `json:"length"`
+	WorkItemID   *int                  `json:"workItemId,omitempty"`
+	Comment      string                `json:"comment,omitempty"`
+	ActivityType *SevenPaceActivityRef `json:"activityType,omitempty"`
+}
+
+type SevenPaceActivityRef struct {
+	ID string `json:"id"`
+}

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -30,6 +30,39 @@ func GetConfig() (string, int, error) {
 	return token, workspaceId, nil
 }
 
+// SevenPaceConfig holds the settings for talking to an on-prem 7pace
+// Timetracker instance using NTLM (Windows) authentication.
+type SevenPaceConfig struct {
+	BaseURL         string
+	Domain          string
+	Username        string
+	Password        string
+	ActivityTypeID  string
+	InsecureSkipTLS bool
+}
+
+// GetSevenPaceConfig reads the 7pace configuration from viper. Base URL,
+// username and password are required; domain and activity type are optional.
+func GetSevenPaceConfig() (SevenPaceConfig, error) {
+	cfg := SevenPaceConfig{
+		BaseURL:         viper.GetString("sevenpace.base_url"),
+		Domain:          viper.GetString("sevenpace.domain"),
+		Username:        viper.GetString("sevenpace.username"),
+		Password:        viper.GetString("sevenpace.password"),
+		ActivityTypeID:  viper.GetString("sevenpace.activity_type_id"),
+		InsecureSkipTLS: viper.GetBool("sevenpace.insecure_skip_verify"),
+	}
+
+	if cfg.BaseURL == "" {
+		return SevenPaceConfig{}, fmt.Errorf("missing sevenpace.base_url in config, please run 'toggl-cli config'")
+	}
+	if cfg.Username == "" || cfg.Password == "" {
+		return SevenPaceConfig{}, fmt.Errorf("missing sevenpace.username or sevenpace.password in config, please run 'toggl-cli config'")
+	}
+
+	return cfg, nil
+}
+
 func GetTimezone() (*time.Location, error) {
 	tz := viper.GetString("toggl.timezone")
 	if tz == "" {


### PR DESCRIPTION
This pull request adds integration with on-prem 7pace Timetracker, allowing users to post Toggl worklogs to 7pace via new CLI commands. It introduces configuration options for 7pace, implements NTLM authentication, provides commands to sync and add worklogs, and includes robust parsing and testing for Azure DevOps work item IDs.

**7pace Timetracker integration:**

* Added support for on-prem 7pace Timetracker by introducing a new `sevenpace` section in the config and prompting for NTLM credentials during `toggl-cli config` setup. Credentials are stored in plaintext due to NTLM requirements. (`README.md`, `cmd/config.go`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R16-R34) [[2]](diffhunk://#diff-c5694d4d0b3b030b84de1d8ea8af2a43dc7b8598525d50a734c100ac22b5fdaaL53-R58) [[3]](diffhunk://#diff-c5694d4d0b3b030b84de1d8ea8af2a43dc7b8598525d50a734c100ac22b5fdaaL62-R119) [[4]](diffhunk://#diff-c5694d4d0b3b030b84de1d8ea8af2a43dc7b8598525d50a734c100ac22b5fdaaR130-R137)
* Implemented a new `SevenPaceClient` in `internal/api/sevenpace-client.go` that uses NTLM authentication (via `go-ntlmssp`) and supports self-signed certificates for corporate environments. (`internal/api/sevenpace-client.go`, `go.mod`) [[1]](diffhunk://#diff-c82a9fbce4250bd4f62e9df935cabad6bd25a68819b2caf7f943df7d2c3b621aR1-R48) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R6)

**New CLI commands for 7pace:**

* Added `toggl-cli 7pace sync` to post Toggl entries for a date range to 7pace as worklogs, parsing work item IDs from entry descriptions and supporting a dry-run mode for preview. (`README.md`, `cmd/sevenpace_sync.go`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R46-R69) [[2]](diffhunk://#diff-14d50e18af4e83a5cee82faea4942dd75fcf9df39a7c04eae45802abe8448180R1-R169)
* Added `toggl-cli 7pace add` to post a single worklog to 7pace, supporting flexible duration and date input. (`README.md`, `cmd/sevenpace_add.go`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R46-R69) [[2]](diffhunk://#diff-1674b0be85cd95a01630887daa82715ce9f708537b96593fc15659f50a983ec1R1-R141)

**Work item ID parsing and utility improvements:**

* Implemented robust parsing for Azure DevOps work item IDs from Toggl entry descriptions, supporting multiple formats. (`cmd/sevenpace.go`)
* Enhanced date parameter handling to support `--today` flag in relevant commands. (`cmd/history.go`)

**Testing:**

* Added comprehensive tests for work item parsing, worklog creation, and duration parsing to ensure correct behavior. (`cmd/sevenpace_test.go`)